### PR TITLE
Fixed the regex for the release builds

### DIFF
--- a/lib/flutter_crashlytics.dart
+++ b/lib/flutter_crashlytics.dart
@@ -13,7 +13,7 @@ class FlutterCrashlytics {
   FlutterCrashlytics._internal();
 
   final regexp = RegExp(
-    '([a-zA-Z ]+)(?:\\.(.*))?\\([a-zA-Z:/_]+\\/([0-9a-zA-Z_-]+.dart):([0-9]+):',
+    '([a-zA-Z ]+)(?:\\.(.*))?\\([a-zA-Z:/_]+\\/([0-9a-zA-Z_-]+.dart):([0-9]+):?',
     caseSensitive: false,
     multiLine: false,
   );


### PR DESCRIPTION
The stack traces do differ between the debug and release builds.
In the debug builds the column number is attached to the line number.
In the release builds the column number is omitted and therefore the
current regular expression does not detect the stack trace line.

Putting the optional colon.