### PR TITLE
Manually log exceptions

### DIFF
--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/CrashActivity.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/CrashActivity.kt
@@ -11,14 +11,7 @@ class CrashActivity : Activity() {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         super.onCreate(savedInstanceState)
         Fabric.with(this, Crashlytics())
-        val cause = intent.getStringExtra("cause")
-        val message = intent.getStringExtra("message")
-        val traces: List<List<Any>> = (intent.extras.getSerializable("trace") as? Array<List<Any>> ?: arrayOf()).toList()
 
-        val data = HashMap<String, Any>()
-        data["cause"] = cause
-        data["message"] = message
-        data["trace"] = traces
-        throw Utils.createException(data)
+        throw intent.getSerializableExtra("exception") as Throwable
     }
 }

--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
@@ -37,9 +37,7 @@ class FlutterCrashlyticsPlugin(private val context: Activity) : MethodCallHandle
                 result.success(null)
             }
             call.method == "logException" -> {
-                val exception = (call.arguments as Map<String, Any>)
-
-                core.logException(Utils.create(exception))
+                core.logException(Utils.create(call.arguments as Map<String, Any>))
 
                 result.success(null)
             }
@@ -72,18 +70,15 @@ class FlutterCrashlyticsPlugin(private val context: Activity) : MethodCallHandle
             call.method == "reportCrash" -> {
                 val exception = (call.arguments as Map<String, Any>)
                 val forceCrash = exception["forceCrash"] as? Boolean ?: false
-                val cause = exception["cause"] as? String
-                val message = exception["message"] as? String
-                val traces = exception["trace"] as? List<List<Any>>
 
-                val throwable = Utils.createException(exception)
+                val throwable = Utils.create(exception)
 
                 if(forceCrash) {
                     //Start a new activity to not crash directly under onMethod call, or it will crash JNI instead of a clean exception
-                    val intent = Intent(context, CrashActivity::class.java)
-                    intent.putExtra("trace", traces?.toTypedArray())
-                    intent.putExtra("cause", cause)
-                    intent.putExtra("message", message)
+                    val intent = Intent(context, CrashActivity::class.java).apply {
+                        putExtra("exception", throwable)
+                    }
+
                     context.startActivityForResult(intent, -1)
                 }
                 else {

--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
@@ -1,10 +1,8 @@
 package com.kiwi.fluttercrashlytics
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import com.crashlytics.android.Crashlytics
-import com.crashlytics.android.core.CrashlyticsCore
 import io.fabric.sdk.android.Fabric
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -36,6 +34,13 @@ class FlutterCrashlyticsPlugin(private val context: Activity) : MethodCallHandle
                     val info = call.arguments as List<Any>
                     core.log(info[0] as Int, info[1] as String, info[2] as String)
                 }
+                result.success(null)
+            }
+            call.method == "logException" -> {
+                val exception = (call.arguments as Map<String, Any>)
+
+                core.logException(Utils.create(exception))
+
                 result.success(null)
             }
             call.method == "setInfo" -> {

--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/Utils.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/Utils.kt
@@ -15,4 +15,22 @@ object Utils {
         throwable.stackTrace = stack.toTypedArray()
         return throwable
     }
+
+    fun create(exception: Map<String, Any>): FlutterException {
+        val message = exception["message"] as? String
+        val traces = exception["trace"] as? List<Map<String, Any>>
+
+        return FlutterException("$message")
+                .apply {
+                    stackTrace = traces?.map(::stackTraceElement)
+                            .orEmpty()
+                            .toTypedArray()
+                }
+    }
+
+    private fun stackTraceElement(map: Map<String, Any>) =
+            StackTraceElement(map["class"] as? String ?: "",
+                              map["method"] as? String ?: "",
+                              map["library"] as? String,
+                              map["line"] as Int)
 }

--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/Utils.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/Utils.kt
@@ -1,26 +1,12 @@
 package com.kiwi.fluttercrashlytics
 
 object Utils {
-    fun createException(exception: Map<String, Any>): FlutterException {
-        val cause = exception["cause"] as? String
-        val message = exception["message"] as? String
-        val traces = exception["trace"] as? List<List<Any>>
-        val stack: MutableList<StackTraceElement> = mutableListOf()
-
-        traces?.forEach {
-            stack.add(StackTraceElement(it[0] as? String ?: "", it[1] as? String
-                    ?: "", it[2] as? String ?: "", it[3] as Int))
-        }
-        val throwable = FlutterException("$message\n$cause")
-        throwable.stackTrace = stack.toTypedArray()
-        return throwable
-    }
 
     fun create(exception: Map<String, Any>): FlutterException {
         val message = exception["message"] as? String
         val traces = exception["trace"] as? List<Map<String, Any>>
 
-        return FlutterException("$message")
+        return FlutterException(message)
                 .apply {
                     stackTrace = traces?.map(::stackTraceElement)
                             .orEmpty()

--- a/lib/flutter_crashlytics.dart
+++ b/lib/flutter_crashlytics.dart
@@ -5,8 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 class FlutterCrashlytics {
-  static const MethodChannel _channel =
-  const MethodChannel('flutter_crashlytics');
+  static const MethodChannel _channel = const MethodChannel('flutter_crashlytics');
   static final FlutterCrashlytics _singleton = FlutterCrashlytics._internal();
 
   factory FlutterCrashlytics() => _singleton;
@@ -71,7 +70,7 @@ class FlutterCrashlytics {
   ///
   /// ```dart
   /// try {
-  ///     // Code throwing en exception
+  ///     // Code throwing an exception
   /// } on Exception catch (e, s) {
   ///     FlutterCrashlytics().logException(e, s);
   /// }

--- a/lib/flutter_crashlytics.dart
+++ b/lib/flutter_crashlytics.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 class FlutterCrashlytics {
   static const MethodChannel _channel =
-      const MethodChannel('flutter_crashlytics');
+  const MethodChannel('flutter_crashlytics');
   static final FlutterCrashlytics _singleton = FlutterCrashlytics._internal();
 
   factory FlutterCrashlytics() => _singleton;
@@ -13,7 +14,7 @@ class FlutterCrashlytics {
   FlutterCrashlytics._internal();
 
   final regexp = RegExp(
-    '([a-zA-Z ]+)(?:\\.(.*))?\\([a-zA-Z:/_]+\\/([0-9a-zA-Z_-]+.dart):([0-9]+):',
+    '([a-zA-Z ]+)(?:\\.(.*))?\\([a-zA-Z:/_]+\\/([0-9a-zA-Z_-]+.dart):([0-9]+):?',
     caseSensitive: false,
     multiLine: false,
   );
@@ -66,4 +67,52 @@ class FlutterCrashlytics {
     return await _channel.invokeMethod(
         'setUserInfo', {"id": identifier, "email": email, "name": name});
   }
+
+  /// Reports an Exception to Craslytics together with the stacktrace.
+  /// Both fields are mandatory.
+  ///
+  /// As Errors should not be cougth those are not supported.
+  ///
+  /// ```dart
+  /// try {
+  ///     // Code throwing en exception
+  /// } on Exception catch (e, s) {
+  ///     FlutterCrashlytics().logException(e, s);
+  /// }
+  /// ```
+  Future<void> logException(Exception exception, StackTrace stack) async {
+    assert(exception != null);
+    assert(stack != null);
+
+    final data = {
+      'message': exception.toString(),
+      'trace': _traces(stack),
+    };
+
+    return await _channel.invokeMethod('logException', data);
+  }
+
+  List<Map<String, dynamic>> _traces(StackTrace stack) =>
+      Trace
+          .from(stack)
+          .frames
+          .map(_toTrace)
+          .toList(growable: false);
+
+  Map<String, dynamic> _toTrace(Frame frame) {
+    final List<String> tokens = frame.member.split('.');
+
+    return {
+      'library': frame.library,
+      'line': frame.line,
+      // Gobal function might have thrown the exception.
+      // So in some cases the method is the first token
+      'method': tokens.length == 1 ? tokens[0] : tokens.sublist(1).join(
+          '.'),
+      // Gobal function might have thrown the exception.
+      // So in some cases class does not exist
+      'class': tokens.length == 1 ? null : tokens[0],
+    };
+  }
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ author: jaumard <jimmy@kiwi-bop.com>
 homepage: https://github.com/kiwi-bop/flutter_crashlytics
 
 dependencies:
+  stack_trace: ^1.9.3
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
I'd like to hear an opinion about this PR.
It contains the mentioned before manual logging of an `Exception` and an `Error`into the Crashlytics.

The experimental part is the usage of [stack_trace](https://github.com/dart-lang/stack_trace) library.
I have noticed in the current implementation that **Global Functions** (with no class) are not correctly parsed by the regex matcher. Matching patterns might be one of the most error-prone parts of the plugin. 
How about using the [stack_trace](https://github.com/dart-lang/stack_trace) library to resolve those issues? It is a standard dart-lang library and will ensure the stack traces are correctly parsed.
Due to the built-in tree shaking of Dart those the lib will have a minimal footprint.

What do you think?

P.S. This implementation of `logException` has only the Android part implemented at the native site. iOS is still missing.