### PR TITLE
Implemented the initialise() call to handle opt-in/out

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ void main() {
     }
   };
 
+  await FlutterCrashlytics().initialise();
+
   runZoned<Future<Null>>(() async {
     runApp(MyApp());
   }, onError: (error, stackTrace) async {
@@ -119,4 +121,4 @@ You can bypass that limitation with the `forceCrash` parameter, instead of the r
 On iOS fatal crash has there dart stacktrace under the `Logs` tab of Crashlytics, that's a limitation of iOS that prevent developers to set a custom stacktrace to an exception. 
 
 ## Contribution
-We love contributions! Don't hesitate to open issues and make pull request to help improve this plugin 
+We love contributions! Don't hesitate to open issues and make pull request to help improve this plugin.

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
 
     <application>
         <activity android:name=".CrashActivity"></activity>
+
+        <meta-data
+                android:name="firebase_crashlytics_collection_enabled"
+                android:value="false" />
     </application>
 
 </manifest>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,6 +21,14 @@ void main() {
     }
   };
 
+  bool optIn = true;
+  if (optIn) {
+    await FlutterCrashlytics().initialise();
+  } else {
+    // In this case Crashlytics won't send any reports.
+    // Usually handling opt in/out is required by the Privacy Regulations
+  }
+
   runZoned<Future<Null>>(() async {
     runApp(MyApp());
   }, onError: (error, stackTrace) async {

--- a/lib/flutter_crashlytics.dart
+++ b/lib/flutter_crashlytics.dart
@@ -12,6 +12,10 @@ class FlutterCrashlytics {
 
   FlutterCrashlytics._internal();
 
+  /// Initialises the Crashlytics plugin.
+  /// If you want to opt in into sending the reports please first call this method.
+  Future<void> initialise() async => await _channel.invokeMethod('initialise');
+
   /// Reports an Error to Craslytics.
   /// A good rule of thumb is not to catch Errors as those are errors that occur
   /// in the development phase.


### PR DESCRIPTION
In order to be compliant with GDPR and other Privacy Regulations
we need to provide the opt-in/out possibility to the client.

If you want to not collect any data please do not call `initialise()`.

@jaumard I have named the "startReporting" method  `initialise()` as it needs to be first called to have things like `log` or `setUserInfo` called on it. It doesn't only refer to the beginning of logging.
@jaumard This seems to be a breaking change (major version increase). Still thinking if it is ok, but the thing is that once you create the Fabric singleton there is no going back. So `initialise()` seems to be necessary. 