### PR TITLE
Fixed crash bug when calling setInfo() on ios.

### DIFF
--- a/ios/Classes/SwiftFlutterCrashlyticsPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrashlyticsPlugin.swift
@@ -88,7 +88,7 @@ public class SwiftFlutterCrashlyticsPlugin: NSObject, FlutterPlugin {
             break
         case "setInfo":
             let info = call.arguments as! Dictionary<String, Any>
-            crashlytics.setValue(info["value"], forKey: info["key"] as! String)
+            crashlytics.setObjectValue(info["value"], forKey: info["key"] as! String)
             result(nil)
             break
         case "setUserInfo":


### PR DESCRIPTION
When calling the following code on ios, crash happened.

```
await FlutterCrashlytics().setInfo("name",  "unknown");
```
It's a simple bug

* setValue -> setObjectValue