### PR TITLE
Skipping initialization for hybrid projects

### DIFF
--- a/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
+++ b/android/src/main/kotlin/com/kiwi/fluttercrashlytics/FlutterCrashlyticsPlugin.kt
@@ -28,6 +28,7 @@ class FlutterCrashlyticsPlugin(private val context: Context) : MethodCallHandler
 
                 result.success(null)
             }
+            "skipInitialization" -> result.success(null)
             else -> {
                 if (Fabric.isInitialized()) {
                     onInitialisedMethodCall(call, result)

--- a/ios/Classes/FlutterCrashlyticsPlugin.m
+++ b/ios/Classes/FlutterCrashlyticsPlugin.m
@@ -38,6 +38,9 @@
         [Fabric with:@[[Crashlytics self]]];
         _isFabricInitialized = true;
         result(nil);
+    } else if ([@"skipInitialization" isEqualToString:call.method]) {
+        _isFabricInitialized = true;
+        result(nil);
     } else if (_isFabricInitialized) {
         [self onInitialisedMethodCall:call result:result];
     } else {
@@ -137,7 +140,7 @@
         [stack appendString: @"\n"];
     }
     CLSLog(@"%@", stack);
-    
+
     FlutterException *ex = [[FlutterException alloc] initWithName:cause reason:reason frameArray:frameArray];
 
     [ex raise];

--- a/lib/flutter_crashlytics.dart
+++ b/lib/flutter_crashlytics.dart
@@ -17,6 +17,10 @@ class FlutterCrashlytics {
   /// If you want to opt in into sending the reports please first call this method.
   Future<void> initialize() async => await _channel.invokeMethod('initialize');
 
+  /// Skip Fabric SDK initialization.
+  /// Specially for hybrid projects, in which Fabric is probably initialized by the native part.
+  Future<void> skipInitialization() => _channel.invokeMethod('skipInitialization');
+
   /// Reports an Error to Crashlytics.
   /// A good rule of thumb is not to catch Errors as those are errors that occur
   /// in the development phase.


### PR DESCRIPTION
I'm doing a hybrid project, mainly in native with embedded flutter views. The Fabric SDK is initialized in the native part, and several configuration params are applied. 
So I added a `skipInitialization` method, to skip the initialization in the flutter part, but still mark it as `initialized` (especially for the iOS platform), it means that the Fabric functionalities are ready to be used.